### PR TITLE
Fixes from PIG-3612

### DIFF
--- a/src/org/apache/pig/builtin/JsonMetadata.java
+++ b/src/org/apache/pig/builtin/JsonMetadata.java
@@ -275,7 +275,8 @@ public class JsonMetadata implements LoadMetadata, StoreMetadata {
     @Override
     public void storeStatistics(ResourceStatistics stats, String location, Job job) throws IOException {
         Configuration conf = job.getConfiguration();
-        DataStorage storage = new HDataStorage(ConfigurationUtil.toProperties(conf));
+        DataStorage storage = new HDataStorage(new Path(location).toUri(),
+                ConfigurationUtil.toProperties(conf));
         ElementDescriptor statFilePath = storage.asElement(location, statFileName);
         if(!statFilePath.exists() && stats != null) {
             try {
@@ -293,7 +294,8 @@ public class JsonMetadata implements LoadMetadata, StoreMetadata {
     @Override
     public void storeSchema(ResourceSchema schema, String location, Job job) throws IOException {
         Configuration conf = job.getConfiguration();
-        DataStorage storage = new HDataStorage(ConfigurationUtil.toProperties(conf));
+        DataStorage storage = new HDataStorage(new Path(location).toUri(),
+                ConfigurationUtil.toProperties(conf));
         ElementDescriptor schemaFilePath = storage.asElement(location, schemaFileName);
         if(!schemaFilePath.exists() && schema != null) {
             try {


### PR DESCRIPTION
Applied patch from https://issues.apache.org/jira/browse/PIG-3612

This very simple patch fixes a bug that blocks the ability to load from one FileSystem implementation and  store to another. For example, the ability to read from HDFS and write to S3. 